### PR TITLE
call parent constructor in GeorchestraRemoteUserView's constructor

### DIFF
--- a/config/superset/GeorchestraCustomizations.py
+++ b/config/superset/GeorchestraCustomizations.py
@@ -34,6 +34,7 @@ class GeorchestraRemoteUserView(AuthRemoteUserView):
     login_template = ''
 
     def __init__(self):
+        super().__init__()
         self.LOGIN_REDIRECT_URL = appbuilder.app.config.get("LOGIN_REDIRECT_URL", "")
         self.LOGOUT_REDIRECT_URL = appbuilder.app.config.get("LOGOUT_REDIRECT_URL", "")
 


### PR DESCRIPTION
fixes #18

otherwise, class_permission_name and base_permissions are None, which blows when superset init is run