### PR TITLE
improved login/user management

### DIFF
--- a/config/superset/GeorchestraCustomizations.py
+++ b/config/superset/GeorchestraCustomizations.py
@@ -124,7 +124,7 @@ class GeorchestraSecurityManager(SupersetSecurityManager):
         super(GeorchestraSecurityManager, self).__init__(appbuilder)
 
 
-def get_flask_current_user() -> FabUser:
+def get_flask_current_user() -> Optional[FabUser]:
     """
     Flask's current_user object can actually be of type werkzeug.LocalProxy while we
     expect a flask_appbuilder.security.sqla.models.User type.
@@ -132,7 +132,12 @@ def get_flask_current_user() -> FabUser:
     underlying object, as explained in https://github.com/apache/superset/issues/29403
     """
     if type(flask_current_user) is LocalProxy:
-        return flask_current_user._get_current_object()
+        try:
+            return flask_current_user._get_current_object()
+        except AttributeError as e:
+            logging.error(f"Error getting current user: {e}")
+            return None
+    # else
     return flask_current_user
 
 

--- a/config/superset/GeorchestraCustomizations.py
+++ b/config/superset/GeorchestraCustomizations.py
@@ -3,29 +3,30 @@ import warnings
 from configparser import ConfigParser
 from datetime import datetime, timedelta
 from itertools import chain
-from typing import Any
+from typing import Any, Optional
 
-from flask import redirect, request, url_for, config as flask_config
+from flask import config as flask_config, flash, g, redirect, request, url_for
 from flask_appbuilder import expose, IndexView
+from flask_appbuilder._compat import as_unicode
 from flask_appbuilder.security.decorators import no_cache
+from flask_appbuilder.security.sqla.models import Role as FabRole, User as FabUser
 from flask_appbuilder.security.views import AuthRemoteUserView
-from flask_login import logout_user as flask_logout_user, login_user as flask_login_user, current_user as flask_current_user
+from flask_appbuilder.utils.base import get_safe_redirect
+from flask_babel import lazy_gettext
+from flask_login import (
+    current_user as flask_current_user,
+    login_user as flask_login_user,
+    logout_user as flask_logout_user,
+)
+from werkzeug.local import LocalProxy
 
-from superset import SupersetSecurityManager, appbuilder, security_manager as sm
+from superset import appbuilder, security_manager as sm, SupersetSecurityManager
 from superset.app import SupersetAppInitializer
 from superset.superset_typing import FlaskResponse
 from superset.utils.log import AbstractEventLogger
 from superset.utils.logging_configurator import LoggingConfigurator
 
-from werkzeug.local import LocalProxy
-
 logger = logging.getLogger(__name__)
-
-def get_flask_current_user():
-    if type(flask_current_user) is LocalProxy:
-        return flask_current_user._get_current_object()
-    return flask_current_user
-
 
 
 class GeorchestraRemoteUserView(AuthRemoteUserView):
@@ -39,7 +40,8 @@ class GeorchestraRemoteUserView(AuthRemoteUserView):
     # => We have to implement a before_request() trigger.
 
     # Leave blank
-    login_template = ''
+    login_template = ""
+    login_issue_message = lazy_gettext("Login issue. Contact your administrator")
 
     def __init__(self):
         super().__init__()
@@ -49,31 +51,70 @@ class GeorchestraRemoteUserView(AuthRemoteUserView):
     @expose("/logout/")
     def logout(self):
         # In theory never used (logout button from superset is hidden)
-        logger.warning(
-            "Logged out from GeorchestraRemoteUserView. This is not expected behaviour")
+        logging.warning(
+            "Logged out from GeorchestraRemoteUserView. This is not expected behaviour"
+        )
         flask_logout_user()
-        return redirect(self.LOGOUT_REDIRECT_URL)
+        if self.LOGOUT_REDIRECT_URL.startswith("http"):
+            # Absolute URL, no change is required
+            return redirect(self.LOGOUT_REDIRECT_URL)
+        else:
+            # Append the root URL (scheme://domainname)
+            root_url = ""
+            try:
+                root_url = request.host_url
+            except AttributeError:
+                logging.error(
+                    f"Could not determine the host root url when calling logout"
+                )
+            return redirect(root_url + self.LOGOUT_REDIRECT_URL)
 
-    @expose('/login/', methods=["GET", "POST"])
+    @expose("/login/", methods=["GET", "POST"])
     @no_cache
     def login(self):
         """
-        If LOGIN_REDIRECT_URL is relative, append it to the URL. Should be the current logic with the Gateway (requires GW >= 2.0.1)
+        If LOGIN_REDIRECT_URL is relative, append it to the URL. Should be the current
+        logic with the Gateway (requires GW >= 2.0.1)
         If not, redirect to the LOGIN_REDIRECT_URL
         """
-        logger.info("Using custom security manager")
-        next_url = request.args.get("next", "")
-        if (self.LOGIN_REDIRECT_URL.startswith("?")
-            and not next_url.endswith(self.LOGIN_REDIRECT_URL)):
-            # Second part is a failsafe to avoid infinite loop if login strategy is not working as expected
-            return redirect(next_url + self.LOGIN_REDIRECT_URL)
-        return redirect(self.LOGIN_REDIRECT_URL)
-
-
-def get_username(environ):
-    user = environ.get('HTTP_SEC_USERNAME', None)
-    environ['REMOTE_USER'] = user
-    return user
+        logging.info("Using custom security manager")
+        # At this point, user authentication should already have happened through the
+        # before_request trigger, see explanantion why above.
+        # so if we are already authenticated, but redirected to this login service, it
+        # means we're not allowed.
+        # => redirect to index page
+        username = request.environ.get(self.appbuilder.sm.auth_remote_user_env_var)
+        next_url = ""
+        if g.user is not None and g.user.is_authenticated or username:
+            next_url = self.appbuilder.get_url_for_index
+            return redirect(get_safe_redirect(next_url))
+            # A warning message informing that the access was not authorized should
+            # be automatically issued
+        else:
+            # anonymous call. Redirect them to the login page
+            next_url = request.args.get("next", "")
+            if self.LOGIN_REDIRECT_URL.startswith("?"):
+                if not next_url.endswith(self.LOGIN_REDIRECT_URL):
+                    # Second part is a failsafe to avoid infinite loop if login strategy
+                    # is not working as expected
+                    next_url = next_url + self.LOGIN_REDIRECT_URL
+                else:
+                    logging.warning(
+                        f"Redirection to login page doesn't seem to work. Redirecting to welcome page"
+                    )
+                    flash(as_unicode(self.login_issue_message), "warning")
+                    next_url = self.appbuilder.get_url_for_index
+            else:
+                root_url = ""
+                try:
+                    root_url = request.host_url
+                except AttributeError:
+                    logging.error(
+                        f"Could not determine the host root url when calling logout"
+                    )
+                next_url = root_url + self.LOGIN_REDIRECT_URL
+        logger.debug(f"Redirecting to {next_url}")
+        return redirect(get_safe_redirect(next_url))
 
 
 class GeorchestraSecurityManager(SupersetSecurityManager):
@@ -83,13 +124,30 @@ class GeorchestraSecurityManager(SupersetSecurityManager):
         super(GeorchestraSecurityManager, self).__init__(appbuilder)
 
 
+def get_flask_current_user() -> FabUser:
+    """
+    Flask's current_user object can actually be of type werkzeug.LocalProxy while we
+    expect a flask_appbuilder.security.sqla.models.User type.
+    In case we get a LocalProxy type, for the login actions, we need to get the
+    underlying object, as explained in https://github.com/apache/superset/issues/29403
+    """
+    if type(flask_current_user) is LocalProxy:
+        return flask_current_user._get_current_object()
+    return flask_current_user
+
+
 class RemoteUserLogin(object):
-    # found at https://github.com/apache/superset/discussions/27451
-    
-    # Frequence to check if user roles list needs to be updated, in minutes. Means DB 
+    """
+    Middleware to extract user info from HTTP headers and login the user.
+    Concept inspired from https://github.com/apache/superset/discussions/27451.
+    Actually handles most of the user management. Loaded by app_init and run before each
+    request
+    """
+
+    # Frequency to check if user roles list needs to be updated, in minutes. Means DB
     # access so we don't want it to happen too often
     roles_default_check_frequency = 5
-    
+
     # A dict. Stores for each logged-in username the last time the roles were checked
     roles_checks = dict()
 
@@ -97,39 +155,94 @@ class RemoteUserLogin(object):
         self.app = app
 
         self.ROLES_PREFIX = app.config.get("GEORCHESTRA_ROLES_PREFIX", "ROLE_SUPERSET_")
-        self.ROLES_CHECK_FREQUENCY = app.config.get("GEORCHESTRA_ROLES_CHECK_FREQUENCY",
-                                                     self.roles_default_check_frequency)
+        self.ROLES_CHECK_FREQUENCY = app.config.get(
+            "GEORCHESTRA_ROLES_CHECK_FREQUENCY", self.roles_default_check_frequency
+        )
         try:
             self.ROLES_CHECK_FREQUENCY = int(self.ROLES_CHECK_FREQUENCY)
         except ValueError:
             self.ROLES_CHECK_FREQUENCY = self.roles_default_check_frequency
-            logger.warning(f"Invalid value for ROLES_CHECK_FREQUENCY: {self.ROLES_CHECK_FREQUENCY}. Using default value: {self.roles_default_check_frequency}")
+            logger.warning(
+                f"Invalid value for ROLES_CHECK_FREQUENCY: {self.ROLES_CHECK_FREQUENCY}. Using default value: {self.roles_default_check_frequency}"
+            )
 
-        self.AUTH_USER_DEFAULT_ROLE = app.config.get("AUTH_USER_REGISTRATION_ROLE",
-                                                     "Public")
+        self.AUTH_USER_DEFAULT_ROLE = app.config.get(
+            "AUTH_USER_REGISTRATION_ROLE", "Public"
+        )
         # We need the user to have at least a Public role, no role at all is _bad_
 
-    def get_valid_roles_from_header(self, georchestra_roles: str) -> list[str]:
+    def _get_username(self) -> Optional[str]:
+        """
+        In geOrchestra context, the username is passed on the HTTP_SEC_USERNAME http header
+        by the Gateway or SP.
+        Superset expects it on the REMOTE_USER header (although not sure it's actually used
+        here)
+        """
+        user = request.environ.get("HTTP_SEC_USERNAME", None)
+        request.environ["REMOTE_USER"] = user
+        return user
+
+    def _user_from_http_headers(self) -> dict:
+        """
+        Read the HTTP headers. Return a dict with the geOrchestra user profile, with
+        roles filtered to the ones matching Superset context.
+        Returns None it no user defined
+        """
+        username = self._get_username()
+        if not username:
+            return {}
+
+        georchestra_roles = request.environ.get("HTTP_SEC_ROLES", "")
+        superset_roles = self._get_valid_roles_from_header(georchestra_roles)
+        return {
+            "username": username,
+            "roles": superset_roles,
+            "first_name": request.environ.get("HTTP_SEC_FIRSTNAME", username),
+            "last_name": request.environ.get("HTTP_SEC_LASTNAME", ""),
+            "email": request.environ.get("HTTP_SEC_EMAIL", ""),
+        }
+
+    def _get_valid_roles_from_header(self, georchestra_roles: str) -> list[FabRole]:
         """
         Split and filter roles based on the list provided in the HTTP headers
-        :param georchestra_roles: comma-separated list of geOrchestra roles. superset relevant roles are expected
-        to have a ROLE_SUPERSET_ prefix
+        :param georchestra_roles: comma-separated list of geOrchestra roles. Superset
+        relevant roles are expected to have a ROLE_SUPERSET_ prefix
         :return: a list of superset-relevant roles
         """
         all_superset_roles = sm.get_all_roles()
 
         roles_list = georchestra_roles.split(";")
-        superset_roles = [role.replace(self.ROLES_PREFIX, "", 1).upper() for role in
-                          roles_list if role.startswith(self.ROLES_PREFIX)]
+        superset_roles = [
+            role.replace(self.ROLES_PREFIX, "", 1).upper()
+            for role in roles_list
+            if role.startswith(self.ROLES_PREFIX)
+        ]
 
-        valid_roles = [r for r in all_superset_roles if r.name.upper() in superset_roles]
+        valid_roles = [
+            r for r in all_superset_roles if r.name.upper() in superset_roles
+        ]
         if not valid_roles:
             # We need the user to have at least a role. If none, let it be `Public`
             valid_roles = [sm.find_role(self.AUTH_USER_DEFAULT_ROLE)]
         return valid_roles
 
+    def _update_user(self, user):
+        user_profile = self._user_from_http_headers()
 
-    def log_user(self, environ) -> tuple[object, bool]:
+        if (
+            set(user_profile["roles"]) != set(user.roles)
+            or user_profile["email"] != user.email
+        ):
+            logger.debug(
+                f"User {user.username} changed since last connection. Updating the profile"
+            )
+            # Then update user definition
+            for k, v in user_profile.items():
+                setattr(user, k, v)
+            sm.update_user(user)
+            flask_login_user(user)
+
+    def log_user(self) -> tuple[object, bool]:
         """
         Handle the login logic based on the HTTP headers and the currently logged-in
         user profile if there is one.
@@ -158,35 +271,37 @@ class RemoteUserLogin(object):
         - whether is was different from an existing session (means the logged-in user
         changed). In that case, we might
         take some measures, like rerouting to the welcome page
-        :param environ:
         :return: (user:object, is_different_user:bool) tuple
         """
         is_different_user = False
-        headers_username = get_username(environ)
+        # Username as advertised by the HTTP headers
+        headers_username = self._get_username()
+        # User as stored by Flask_login session
         current_user = get_flask_current_user()
+
+        # If they match:
         if current_user and current_user.is_authenticated:
             if current_user.username == headers_username:
-                logging.debug(f"Remote user {headers_username} already logged")
+                logger.debug(f"Remote user {headers_username} already logged")
                 # Check if roles have changed since the session was started
                 # Check is done every GEORCHESTRA_ROLES_CHECK_FREQUENCY times only,
                 # to avoid calling DB on each call of the log_user function
                 # (can happen more than 10 times per page load)
-                last_check = self.roles_checks.get(headers_username, datetime.fromtimestamp(0))
-                if datetime.now() > last_check + timedelta(minutes=self.ROLES_CHECK_FREQUENCY):
-                    logging.debug(f"Checking if roles for {headers_username} are up-to-date since last check ({last_check})")
+                last_check = self.roles_checks.get(
+                    headers_username, datetime.fromtimestamp(0)
+                )
+                if datetime.now() > last_check + timedelta(
+                    minutes=self.ROLES_CHECK_FREQUENCY
+                ):
+                    logger.debug(
+                        f"Checking if roles for {headers_username} are up-to-date since last check ({last_check})"
+                    )
                     self.roles_checks[headers_username] = datetime.now()
-                    georchestra_roles = environ.get('HTTP_SEC_ROLES', "")
-                    r = self.get_valid_roles_from_header(georchestra_roles)
-                    current_roles=current_user.roles
-                    if set(r) != set(current_user.roles):
-                        # Then update roles in user definition
-                        current_user.roles = r
-                        sm.update_user(current_user)
-                        flask_login_user(current_user)
-                # current_user is actually of type werkzeug.LocalProxy. We should return the underlying object, as explained in https://github.com/apache/superset/issues/29403
+                    self._update_user(current_user)
                 return current_user, False
             else:
-                # The user changed since last request, log him out and switch to new user
+                # No match, the user changed since last request, log him out
+                # and switch to new user
                 flask_logout_user()
                 is_different_user = True
 
@@ -204,30 +319,16 @@ class RemoteUserLogin(object):
         # Retrieve the user from the DB, if he exists
         user = sm.find_user(username=headers_username)
         # Retrieve roles from http header and filter to the ones relevant in Superset context
-        georchestra_roles = environ.get('HTTP_SEC_ROLES', "")
-        user_roles = self.get_valid_roles_from_header(georchestra_roles)
 
         # Update the user if he exists, create him if not
         if user:
             logger.debug("New user logged in: %s", user.username)
-            if user.roles != user_roles:
-                logger.debug("User exists but roles differ. Updating profile")
-                # Update relevant profile information
-                user.roles = user_roles
-                user.email =request.headers.environ.get('HTTP_SEC_EMAIL', "")
-                sm.update_user(user)
+            self._update_user(user)
         else:
             # Create user
             logger.debug("User not found, creating it")
-            user = sm.add_user(
-                    username=headers_username,
-                    first_name=request.headers.environ.get('HTTP_SEC_FIRSTNAME',
-                        headers_username),
-                    last_name=request.headers.environ.get('HTTP_SEC_LASTNAME', ""),
-                    email=request.headers.environ.get('HTTP_SEC_EMAIL', ""),
-                    role=user_roles
-               )
-
+            user_profile = self._user_from_http_headers()
+            user = sm.add_user(**user_profile)
             user = sm.auth_user_remote_user(headers_username)
 
         flask_login_user(user)
@@ -239,17 +340,18 @@ class RemoteUserLogin(object):
         Important things here happen in log_user function
         :return:
         """
-        user, is_different_user = self.log_user(request.environ)
-        logger.debug(f"Current user object is of type {type(user)}")
+        user, is_different_user = self.log_user()
+        # logger.debug(f"Current user object is of type {type(user)}")
         if not user:
             logger.debug("Logged in as anonymous user")
         else:
-            logger.debug(f"User logged in as {user}, roles {user.roles}")
+            logger.debug(f"User logged in as {user} ({user.username}), roles {user.roles}")
 
 
 class GeorchestraContextProcessor(object):
     """
-    Provide a context_processor that will inject configuration data into the jinja2 templates.
+    Provide a context_processor that will inject configuration data into the jinja2
+    templates.
     It will support
     - parsing default.properties geOrchestra configuration file
     - parsing config values from the superset config files
@@ -258,8 +360,9 @@ class GeorchestraContextProcessor(object):
     def __init__(self, app):
         self.sections = None
         self.app = app
-        self.properties_file_path = app.config.get("GEORCHESTRA_PROPERTIES_FILE_PATH",
-                                                   "")
+        self.properties_file_path = app.config.get(
+            "GEORCHESTRA_PROPERTIES_FILE_PATH", ""
+        )
         self.noheader = app.config.get("GEORCHESTRA_NOHEADER", False)
 
     def init_app(self) -> None:
@@ -278,7 +381,11 @@ class GeorchestraContextProcessor(object):
         :return:
         """
         if self.noheader:
-            return {"georchestra": {'noheader': True, }}
+            return {
+                "georchestra": {
+                    "noheader": True,
+                }
+            }
 
         self.sections = dict()
         if self.properties_file_path:
@@ -288,28 +395,31 @@ class GeorchestraContextProcessor(object):
                 # does the trick:
                 lines = chain(("[section]",), lines)
                 parser.read_file(lines)
-                self.sections['default'] = parser['section']
+                self.sections["default"] = parser["section"]
         properties = {
-            'headerScript': self.get("GEORCHESTRA_HEADER_SCRIPT", 'headerScript'),
-            'headerHeight': self.get("GEORCHESTRA_HEADER_HEIGHT", 'headerHeight'),
-            'headerUrl': self.get("GEORCHESTRA_HEADER_URL", 'headerUrl'),
-            'headerConfigFile': self.get("GEORCHESTRA_HEADER_CONFIG_FILE",
-                                         'headerConfigFile'),
-            'useLegacyHeader': self.get("GEORCHESTRA_HEADER_LEGACY_HEADER",
-                                        'useLegacyHeader'),
-            'georchestraStyleSheet': self.get("GEORCHESTRA_HEADER_STYLESHEET",
-                                              'georchestraStyleSheet'),
-            'logoUrl': self.get("GEORCHESTRA_LOGO_URL", 'logoUrl'),
-            'noheader': self.noheader,
+            "headerScript": self.get("GEORCHESTRA_HEADER_SCRIPT", "headerScript"),
+            "headerHeight": self.get("GEORCHESTRA_HEADER_HEIGHT", "headerHeight"),
+            "headerUrl": self.get("GEORCHESTRA_HEADER_URL", "headerUrl"),
+            "headerConfigFile": self.get(
+                "GEORCHESTRA_HEADER_CONFIG_FILE", "headerConfigFile"
+            ),
+            "useLegacyHeader": self.get(
+                "GEORCHESTRA_HEADER_LEGACY_HEADER", "useLegacyHeader"
+            ),
+            "georchestraStyleSheet": self.get(
+                "GEORCHESTRA_HEADER_STYLESHEET", "georchestraStyleSheet"
+            ),
+            "logoUrl": self.get("GEORCHESTRA_LOGO_URL", "logoUrl"),
+            "noheader": self.noheader,
         }
         return {"georchestra": properties}
 
-    def get(self, param_key, prop_key, section='default'):
+    def get(self, param_key, prop_key, section="default"):
         """
         :param param_key: key allowed in superset config files
         :param prop_key: key allowed in geOrchestra config files
-        :param section: 
-        :return: 
+        :param section:
+        :return:
         """
         if self.app.config.get(param_key):
             return self.app.config.get(param_key)
@@ -323,13 +433,16 @@ class GeorchestraContextProcessor(object):
 # You can either define a path (including the potential prefix)
 # or a view name
 
+
 class SupersetIndexView(IndexView):
     @expose("/")
     def index(self) -> FlaskResponse:
-        welcome_viewname = self.appbuilder.app.config.get("HOME_PAGE_VIEW",
-                                                          "Superset.welcome")
-        welcome_path = self.appbuilder.app.config.get("HOME_PAGE_PATH",
-                                                      url_for(welcome_viewname))
+        welcome_viewname = self.appbuilder.app.config.get(
+            "HOME_PAGE_VIEW", "Superset.welcome"
+        )
+        welcome_path = self.appbuilder.app.config.get(
+            "HOME_PAGE_PATH", url_for(welcome_viewname)
+        )
         return redirect(welcome_path)
 
 
@@ -339,8 +452,9 @@ def app_init(app):
     app.before_request(RemoteUserLogin(app).before_request)
 
     # Set the home page
-    app.config[
-        'FAB_INDEX_VIEW'] = f"{SupersetIndexView.__module__}.{SupersetIndexView.__name__}"
+    app.config["FAB_INDEX_VIEW"] = (
+        f"{SupersetIndexView.__module__}.{SupersetIndexView.__name__}"
+    )
 
     # Read default.properties file from geOrchestra datadir
     # Used to configure the geOrchestra header (unless superset's config
@@ -348,6 +462,7 @@ def app_init(app):
     # no header will be shown)
     GeorchestraContextProcessor(app).init_app()
     return SupersetAppInitializer(app)
+
 
 # Alternatively, this should also be possible using FLASK_APP_MUTATOR
 # see https://superset.apache.org/docs/configuration/configuring-superset/
@@ -372,6 +487,7 @@ class NullEventLogger(AbstractEventLogger):
     ) -> None:
         pass
 
+
 # TODO: an event logger that will log interesting events to the analytics module
 
 
@@ -384,10 +500,12 @@ class CustomLoggingConfigurator(LoggingConfigurator):
 
         # Ignore Werkzeug LocalProxy errors. Doesn't seem to work right now)
         # https://github.com/apache/superset/issues/29403#issuecomment-2532848376
-        warnings.filterwarnings("ignore", message = ".*werkzeug.local.LocalProxy.*")
+        warnings.filterwarnings("ignore", message=".*werkzeug.local.LocalProxy.*")
 
         # basicConfig() will set up a default StreamHandler on stderr
         logging.basicConfig(format=app_config["LOG_FORMAT"])
         logging.getLogger().setLevel(app_config["LOG_LEVEL"])
 
-        logger.info("Logging was configured successfully using CustomLoggingConfigurator")
+        logger.info(
+            "Logging was configured successfully using CustomLoggingConfigurator"
+        )

--- a/config/superset/GeorchestraCustomizations.py
+++ b/config/superset/GeorchestraCustomizations.py
@@ -49,7 +49,17 @@ class GeorchestraRemoteUserView(AuthRemoteUserView):
     @expose('/login/', methods=["GET", "POST"])
     @no_cache
     def login(self):
+        """
+        If LOGIN_REDIRECT_URL is relative, append it to the URL. Should be the 
+        current logic with the Gateway (requires GW >= 2.0.1)
+        If not, redirect to the LOGIN_REDIRECT_URL
+        """
         logger.info("Using custom security manager")
+        next_url = request.args.get("next", "")
+        if (self.LOGIN_REDIRECT_URL.startswith("?")
+            and not next_url.endswith(self.LOGIN_REDIRECT_URL)):
+            # Second part is a failsafe to avoid infinite loop if login strategy is not working as expected
+            return redirect(next_url + self.LOGIN_REDIRECT_URL)
         return redirect(self.LOGIN_REDIRECT_URL)
 
 

--- a/config/superset/GeorchestraCustomizations.py
+++ b/config/superset/GeorchestraCustomizations.py
@@ -328,6 +328,8 @@ class RemoteUserLogin(object):
             # Create user
             logger.debug("User not found, creating it")
             user_profile = self._user_from_http_headers()
+            # Rename key "roles" to "role" to match the add_user function definition"
+            user_profile["role"] = user_profile.pop("roles", [])
             user = sm.add_user(**user_profile)
             user = sm.auth_user_remote_user(headers_username)
 

--- a/config/superset/superset_georchestra_config.py
+++ b/config/superset/superset_georchestra_config.py
@@ -72,7 +72,10 @@ GEORCHESTRA_ROLES_CHECK_FREQUENCY = 5 #minutes
 PUBLIC_ROLE_LIKE = "Guest_template"
 AUTH_USER_REGISTRATION_ROLE = "Public"
 LOGOUT_REDIRECT_URL = "/logout"
-LOGIN_REDIRECT_URL = "/login?service="
+# This one might be for SP
+# LOGIN_REDIRECT_URL = "/login?service="
+# This one will work best on Gateway >= 2.0.1
+LOGIN_REDIRECT_URL = "?login"
 
 # Disable default event logging (stored in DB by default, which can bloat the DB,
 # cf https://github.com/apache/superset/discussions/23110).


### PR DESCRIPTION
Cleaner handling of remote_user login/auth.

## Fixes
Solves:
- https://github.com/georchestra/superset/issues/24
- https://github.com/georchestra/superset/issues/23
- https://github.com/georchestra/superset/issues/20

## Known possible issues
This does not handle the case when a user updates his email in the console and this new email conflicts with an already existing user in the Superset DB. This is very unlikely. But since there is some cache going on, one might for instance change his username _and_ email in a short span of time which might result in a "duplicate" causing conflict. 

One way of resolving this could be to revert back either the email or the username, login again in Superset so that it detects the change, _then_ modify the remaining attribute  (username or email) and come back to Superset.

Another way would be for a Superset admin to edit in Superset the user record in the DB.

## Login redirect when requesting a non-public URL 

Standard way to handle login with the gateway  is now by appending `?login` to the requested URL. This is configured with the following config parameter: 
```yaml
LOGIN_REDIRECT_URL = "?login"
```

This should ensure proper redirection to the requested URL right after a successful login, and supposing your are allowed to access the resource (otherwise you'll be redirected to the welcome page, e.g. the dashboards list)
Gateway is now considered as the default entrypoint (replaces the SP), so this config comes as default.